### PR TITLE
Bugfix/UIPSelectSetting: empty option processing

### DIFF
--- a/src/plugins/settings/settings/setting/select-setting/select-setting.ts
+++ b/src/plugins/settings/settings/setting/select-setting/select-setting.ts
@@ -1,12 +1,12 @@
 import {attr, boolAttr} from '@exadel/esl/modules/esl-base-element/core';
+import type {ESLSelect} from '@exadel/esl/modules/esl-forms/esl-select/core';
 import {randUID} from '@exadel/esl/modules/esl-utils/misc/uid';
+import {memoize} from '@exadel/esl/modules/esl-utils/decorators/memoize';
 
 import {UIPSetting} from '../setting';
 import {ChangeAttrConfig, UIPStateModel} from '../../../../../core/base/model';
 import TokenListUtils from '../../../../../utils/token-list-utils';
 import {WARNING_MSG} from '../../../../../utils/warning-msg';
-
-import type {ESLSelect} from '@exadel/esl/modules/esl-forms/esl-select/core';
 
 /**
  * Custom setting for selecting attribute's value.
@@ -30,6 +30,7 @@ export class UIPSelectSetting extends UIPSetting {
   /** Select field to change setting's value. */
   protected $field: ESLSelect;
 
+  @memoize()
   protected get settingOptions(): string[] {
     return this.$field.options.map(opt => opt.value);
   }
@@ -112,14 +113,18 @@ export class UIPSelectSetting extends UIPSetting {
     return this.multiple ? this.setValue('') : this.setInconsistency(WARNING_MSG.noMatch);
   }
 
-  /** Update setting's value for append {@link mode}. */
+  /** Update setting's value for {@link mode} = "append". */
   protected updateAppend(attrValues: (string | null)[]): void {
-    const optionsIntersections = attrValues.map(val => TokenListUtils.intersection(this.settingOptions, TokenListUtils.split(val)));
+    // array of each attribute's value intersection with select options
+    const valuesOptions = attrValues.map(val => TokenListUtils.intersection(this.settingOptions, TokenListUtils.split(val)));
 
-    if (this.settingOptions.includes('') && optionsIntersections.every(inter => !inter.length)) {
+    // make empty option active if no options intersections among attribute values
+    if (this.settingOptions.includes('') && valuesOptions.every(inter => !inter.length)) {
       return this.setValue('');
     }
-    const commonOptions = TokenListUtils.intersection(...optionsIntersections);
+
+    // common options among all attribute values
+    const commonOptions = TokenListUtils.intersection(...valuesOptions);
 
     if (this.multiple || commonOptions.length) return this.setValue(TokenListUtils.join(commonOptions));
 

--- a/src/plugins/settings/settings/setting/select-setting/select-setting.ts
+++ b/src/plugins/settings/settings/setting/select-setting/select-setting.ts
@@ -2,7 +2,7 @@ import {attr, boolAttr} from '@exadel/esl/modules/esl-base-element/core';
 import {randUID} from '@exadel/esl/modules/esl-utils/misc/uid';
 
 import {UIPSetting} from '../setting';
-import {ChangeAttrConfig, UIPStateModel} from '../../../../../core/registration';
+import {ChangeAttrConfig, UIPStateModel} from '../../../../../core/base/model';
 import TokenListUtils from '../../../../../utils/token-list-utils';
 import {WARNING_MSG} from '../../../../../utils/warning-msg';
 
@@ -114,8 +114,12 @@ export class UIPSelectSetting extends UIPSetting {
 
   /** Update setting's value for append {@link mode}. */
   protected updateAppend(attrValues: (string | null)[]): void {
-    const commonOptions = TokenListUtils.intersection(
-      ...attrValues.map(val => TokenListUtils.split(val)), this.settingOptions);
+    const optionsIntersections = attrValues.map(val => TokenListUtils.intersection(this.settingOptions, TokenListUtils.split(val)));
+
+    if (this.settingOptions.includes('') && optionsIntersections.every(inter => !inter.length)) {
+      return this.setValue('');
+    }
+    const commonOptions = TokenListUtils.intersection(...optionsIntersections);
 
     if (this.multiple || commonOptions.length) return this.setValue(TokenListUtils.join(commonOptions));
 

--- a/src/utils/token-list-utils.ts
+++ b/src/utils/token-list-utils.ts
@@ -26,10 +26,11 @@ export default class TokenListUtils {
 
   /** Get array which contains only common elements from arrays. */
   static intersection<T>(...arrays: T[][]): T[] {
-    return Array.from(arrays.reduce((intersect, arr) => {
-      arr.forEach(val => !intersect.has(val) && intersect.delete(val));
+    const sets = arrays.map(arr => new Set(arr));
+    return Array.from(sets.reduce((intersect, set) => {
+      intersect.forEach(val => !set.has(val) && intersect.delete(val));
       return intersect;
-    }, new Set(arrays[0])));
+    }, sets[0]));
   }
 
   /** Remove all element appearances from array. */

--- a/src/utils/token-list-utils.ts
+++ b/src/utils/token-list-utils.ts
@@ -25,12 +25,10 @@ export default class TokenListUtils {
   }
 
   /** Get array which contains only common elements from arrays. */
-  static intersection<T>(...arrays: T[][]): T[] {
-    const sets = arrays.map(arr => new Set(arr));
-    return Array.from(sets.reduce((intersect, set) => {
-      intersect.forEach(val => !set.has(val) && intersect.delete(val));
-      return intersect;
-    }, sets[0]));
+  static intersection<T>(...rest: T[][]): T[];
+  static intersection<T>(a: T[], b: T[], ...rest: T[][]): T[] {
+    if (rest.length) return TokenListUtils.intersection(a, TokenListUtils.intersection(b, ...rest));
+    return a.filter(Set.prototype.has, new Set(b));
   }
 
   /** Remove all element appearances from array. */


### PR DESCRIPTION
Fix processing UIPSelectSetting's value when "empty" option (`<option value="">None</option>`) is present