### PR TITLE
Fix: active snippet init added

### DIFF
--- a/pages/views/examples/example/list.njk
+++ b/pages/views/examples/example/list.njk
@@ -13,7 +13,7 @@ title: Example with list of cards
       <div class="card-item aqua">Card #3</div>
     </div>
   </script>
-  <script type="text/html" uip-snippet label="Long list of red cards containing seven items" wrap-items>
+  <script type="text/html" uip-snippet active label="Long list of red cards containing seven items" wrap-items>
     <div class="card-list">
       <div class="card-item red">Card #1</div>
       <div class="card-item red">Card #2</div>

--- a/src/core/base/model.ts
+++ b/src/core/base/model.ts
@@ -85,7 +85,7 @@ export class UIPStateModel extends Observable {
   public get activeSnippet(): SnippetTemplate {
     if (!this._activeSnippet) {
       this._activeSnippet = this.snippets
-        .find( (snippet: SnippetTemplate) => snippet.hasAttribute('active')) || this.snippets[0];
+        .find((snippet: SnippetTemplate) => snippet.hasAttribute('active')) || this.snippets[0];
     }
     return this._activeSnippet;
   }

--- a/src/core/base/model.ts
+++ b/src/core/base/model.ts
@@ -83,13 +83,23 @@ export class UIPStateModel extends Observable {
 
   /** Current active {@link SnippetTemplate} getter */
   public get activeSnippet(): SnippetTemplate {
+    if (!this._activeSnippet) {
+      this._activeSnippet = this.snippets
+        .find( (snippet: SnippetTemplate) => snippet.hasAttribute('active')) || this.snippets[0];
+    }
     return this._activeSnippet;
+  }
+
+  public set activeSnippet(snippet: SnippetTemplate) {
+    this._activeSnippet.removeAttribute('active');
+    snippet.setAttribute('active', '');
+    this._activeSnippet = snippet;
   }
 
   /** Changes current active snippet */
   public applySnippet(snippet: SnippetTemplate, modifier: UIPPlugin | UIPRoot) {
     if (!snippet) return;
-    this._activeSnippet = snippet;
+    this.activeSnippet = snippet;
     this.setHtml(snippet.innerHTML, modifier);
   }
 

--- a/src/core/base/root.ts
+++ b/src/core/base/root.ts
@@ -56,7 +56,7 @@ export class UIPRoot extends ESLBaseElement {
   /** Initial initialization of snippets */
   protected initSnippets(): void {
     this.model.snippets = this.$snippets;
-    this.model.applySnippet(this.model.snippets[0], this);
+    this.model.applySnippet(this.model.activeSnippet, this);
   }
 
   protected attributeChangedCallback(attrName: string, oldVal: string | null, newVal: string | null) {

--- a/src/plugins/header/snippets/snippets.ts
+++ b/src/plugins/header/snippets/snippets.ts
@@ -17,7 +17,7 @@ export class UIPSnippets extends UIPPlugin {
   /** CSS Class added to active snippet */
   public static ACTIVE_ITEM = 'active';
   /** Index of current snippet list item */
-  public currentIndex = 0;
+  public currentIndex: number;
 
   /** Snippets container element */
   @memoize()
@@ -77,7 +77,6 @@ export class UIPSnippets extends UIPPlugin {
   protected connectedCallback() {
     super.connectedCallback();
     this.render();
-    this.updateTitleText();
     // Initial update
     setTimeout(() => this.$active = this.$active || this.$items[0]);
   }
@@ -105,6 +104,7 @@ export class UIPSnippets extends UIPPlugin {
   /** Sets active snippet element */
   public set $active(snippet: HTMLElement | null) {
     this.$items.forEach((item) => item.classList.toggle(UIPSnippets.ACTIVE_ITEM, snippet === item));
+    this.updateTitleText();
   }
 
   /** Initializes snippets layout */
@@ -143,6 +143,7 @@ export class UIPSnippets extends UIPPlugin {
     const $li = document.createElement('li');
     $li.classList.add(UIPSnippets.LIST_ITEM);
     $li.textContent = label;
+    snippet === this.model?.activeSnippet && $li.classList.add(UIPSnippets.ACTIVE_ITEM);
     return $li;
   }
 
@@ -166,7 +167,6 @@ export class UIPSnippets extends UIPPlugin {
       this.model.applySnippet(this.model.snippets[index], this);
       this.$active = target;
       this.currentIndex = index;
-      this.updateTitleText();
     }
   }
 


### PR DESCRIPTION
'active' attribute could be added to one of snippet templates to set is as active on playground init; 