### PR TITLE
feat: isolated renderer and basic JS support

### DIFF
--- a/pages/views/examples/example/form.njk
+++ b/pages/views/examples/example/form.njk
@@ -24,6 +24,13 @@ title: Example with form
       <input type="submit" value="Send">
     </form>
   </script>
+  <script type="text/plain" uip-js-snippet label="Example with form">
+    document.querySelector('form').onsubmit = (e) => {
+      e.preventDefault();
+      const json = JSON.stringify(Object.fromEntries(new FormData(e.target)));
+      alert(`Form submitted with ${json}!`);
+    };
+  </script>
 
   <uip-preview class="centered-content" resizable isolation></uip-preview>
 
@@ -32,4 +39,5 @@ title: Example with form
   </uip-settings>
 
   <uip-editor copy collapsible label="Markdown"></uip-editor>
+  <uip-editor script copy collapsible label="JavaScript"></uip-editor>
 </uip-root>

--- a/pages/views/examples/example/form.njk
+++ b/pages/views/examples/example/form.njk
@@ -25,7 +25,7 @@ title: Example with form
     </form>
   </script>
 
-  <uip-preview class="centered-content" resizable></uip-preview>
+  <uip-preview class="centered-content" resizable isolation></uip-preview>
 
   <uip-settings resizable vertical="@+sm" target=".demo-form">
     <uip-bool-setting label="Email validation" target="#email" mode="append" attribute="class" value="validation-input"></uip-bool-setting>

--- a/src/core/base/model.ts
+++ b/src/core/base/model.ts
@@ -2,7 +2,7 @@ import {SyntheticEventTarget} from '@exadel/esl/modules/esl-utils/dom';
 import {decorate} from '@exadel/esl/modules/esl-utils/decorators';
 import {microtask} from '@exadel/esl/modules/esl-utils/async';
 
-import {UIPNormalizationService} from '../processors/normalization';
+import {UIPJSNormalizationPreprocessors, UIPHTMLNormalizationPreprocessors} from '../processors/normalization';
 import {UIPSnippetItem} from './snippet';
 
 import type {UIPRoot} from './root';
@@ -55,7 +55,7 @@ export class UIPStateModel extends SyntheticEventTarget {
    * @param modifier - plugin, that initiates the change
    */
   public setJS(js: string, modifier: UIPPlugin | UIPRoot): void {
-    const script = UIPNormalizationService.normalize(js, false);
+    const script = UIPJSNormalizationPreprocessors.preprocess(js);
     if (this._js === script) return;
     this._js = script;
     this._lastModifier = modifier;
@@ -68,7 +68,7 @@ export class UIPStateModel extends SyntheticEventTarget {
    * @param modifier - plugin, that initiates the change
    */
   public setHtml(markup: string, modifier: UIPPlugin | UIPRoot): void {
-    const html = UIPNormalizationService.normalize(markup);
+    const html = UIPHTMLNormalizationPreprocessors.preprocess(markup);
     const root = new DOMParser().parseFromString(html, 'text/html').body;
     if (!root || root.innerHTML.trim() !== this.html.trim()) {
       this._html = root;

--- a/src/core/base/model.ts
+++ b/src/core/base/model.ts
@@ -2,7 +2,7 @@ import {SyntheticEventTarget} from '@exadel/esl/modules/esl-utils/dom';
 import {decorate} from '@exadel/esl/modules/esl-utils/decorators';
 import {microtask} from '@exadel/esl/modules/esl-utils/async';
 
-import {UIPHtmlNormalizationService} from '../processors/normalization';
+import {UIPNormalizationService} from '../processors/normalization';
 import {UIPSnippetItem} from './snippet';
 
 import type {UIPRoot} from './root';
@@ -42,10 +42,25 @@ export class UIPStateModel extends SyntheticEventTarget {
   /** Snippets {@link UIPSnippetItem} value objects */
   private _snippets: UIPSnippetItem[];
 
+  /** Current js state */
+  private _js: string = '';
   /** Current markup state */
   private _html = new DOMParser().parseFromString('', 'text/html').body;
   /** Last {@link UIPPlugin} element which changed markup */
   private _lastModifier: UIPPlugin | UIPRoot;
+
+  /**
+   * Sets current js state to the passed one
+   * @param js - new state
+   * @param modifier - plugin, that initiates the change
+   */
+  public setJS(js: string, modifier: UIPPlugin | UIPRoot): void {
+    const script = UIPNormalizationService.normalize(js, false);
+    if (this._js === script) return;
+    this._js = script;
+    this._lastModifier = modifier;
+    this.dispatchChange();
+  }
 
   /**
    * Sets current markup state to the passed one
@@ -53,13 +68,18 @@ export class UIPStateModel extends SyntheticEventTarget {
    * @param modifier - plugin, that initiates the change
    */
   public setHtml(markup: string, modifier: UIPPlugin | UIPRoot): void {
-    const html = UIPHtmlNormalizationService.normalize(markup);
+    const html = UIPNormalizationService.normalize(markup);
     const root = new DOMParser().parseFromString(html, 'text/html').body;
     if (!root || root.innerHTML.trim() !== this.html.trim()) {
       this._html = root;
       this._lastModifier = modifier;
       this.dispatchChange();
     }
+  }
+
+  /** Current js state getter */
+  public get js(): string {
+    return this._js;
   }
 
   /** Current markup state getter */
@@ -98,6 +118,7 @@ export class UIPStateModel extends SyntheticEventTarget {
     if (!snippet) return;
     this._snippets.forEach((s) => (s.active = s === snippet));
     this.setHtml(snippet.html, modifier);
+    this.setJS(snippet.js, modifier);
     this.dispatchEvent(
       new CustomEvent('uip:model:snippet:change', {detail: this})
     );

--- a/src/core/base/root.less
+++ b/src/core/base/root.less
@@ -13,7 +13,8 @@ uip-root {
     'header header'
     'preview sidebar'
     'settings settings'
-    'editor editor';
+    'editor editor'
+    'editor-js editor-js';
 
   min-width: 100%;
   height: auto;

--- a/src/core/base/snippet.ts
+++ b/src/core/base/snippet.ts
@@ -12,7 +12,7 @@ export class UIPSnippetItem {
     const $root = this.$element.closest('uip-root') || document.body;
     const selectors = [];
     if (this.$element.id) selectors.push(`[uip-js-snippet="${this.$element.id}"]`);
-    if (this.label) selectors.push(`[uip-js-snippet="${this.label}"]`, `[uip-js-snippet][label="${this.label}"]`);
+    if (this.label) selectors.push(`[uip-js-snippet][label="${this.label}"]`);
     return $root.querySelector(selectors.join(',')) as UIPSnippetTemplate;
   }
 

--- a/src/core/base/snippet.ts
+++ b/src/core/base/snippet.ts
@@ -7,6 +7,15 @@ export type UIPSnippetTemplate = HTMLTemplateElement | HTMLScriptElement;
 export class UIPSnippetItem {
   public constructor(protected readonly $element: UIPSnippetTemplate) {}
 
+  @memoize()
+  public get $elementJS(): UIPSnippetTemplate | null {
+    const $root = this.$element.closest('uip-root') || document.body;
+    const selectors = [];
+    if (this.$element.id) selectors.push(`[uip-js-snippet="${this.$element.id}"]`);
+    if (this.label) selectors.push(`[uip-js-snippet="${this.label}"]`, `[uip-js-snippet][label="${this.label}"]`);
+    return $root.querySelector(selectors.join(',')) as UIPSnippetTemplate;
+  }
+
   /** @returns snippet's label */
   @memoize()
   public get label(): string {
@@ -19,6 +28,11 @@ export class UIPSnippetItem {
     return this.$element.innerHTML;
   }
 
+  @memoize()
+  public get js(): string {
+    return this.$elementJS ? this.$elementJS.innerHTML : '';
+  }
+
   /** @returns if the snippet is in active state */
   public get active(): boolean {
     return this.$element.hasAttribute('active');
@@ -26,7 +40,7 @@ export class UIPSnippetItem {
 
   /** Sets the snippet active state */
   public set active(active: boolean) {
-    if (active) this.$element.setAttribute('active', '');
-    else this.$element.removeAttribute('active');
+    this.$element.toggleAttribute('active', active);
+    this.$elementJS?.toggleAttribute('active', active);
   }
 }

--- a/src/core/preview/preview.less
+++ b/src/core/preview/preview.less
@@ -39,6 +39,12 @@
     max-height: 100%;
   }
 
+  &-iframe {
+    width: 100%;
+    min-height: 100%;
+    border: none;
+  }
+
   &.centered-content &-inner {
     margin: auto;
   }

--- a/src/core/preview/preview.tsx
+++ b/src/core/preview/preview.tsx
@@ -1,10 +1,15 @@
 import React from 'jsx-dom';
 
-import {listen, memoize} from '@exadel/esl/modules/esl-utils/decorators';
+import {attr, listen, memoize} from '@exadel/esl/modules/esl-utils/decorators';
+import {ESLIntersectionTarget} from '@exadel/esl/modules/esl-event-listener/core';
+import {parseBoolean, toBooleanAttribute} from '@exadel/esl/modules/esl-utils/misc';
 import {afterNextRender, skipOneRender} from '@exadel/esl/modules/esl-utils/async';
 
 import {UIPPlugin} from '../base/plugin';
+import {UIPRenderingTemplatesService} from '../processors/templates';
 import {UIPRenderingPreprocessorService} from '../processors/rendering';
+
+import type {ESLIntersectionEvent} from '@exadel/esl/modules/esl-event-listener/core';
 
 /**
  * Preview {@link UIPPlugin} custom element definition.
@@ -12,13 +17,25 @@ import {UIPRenderingPreprocessorService} from '../processors/rendering';
  */
 export class UIPPreview extends UIPPlugin {
   static is = 'uip-preview';
-  static observedAttributes: string[] = ['dir', 'resizable'];
+  static observedAttributes: string[] = ['dir', 'resizable', 'isolation', 'isolation-template'];
+
+  /** Marker to use iframe isolated rendering */
+  @attr({parser: parseBoolean, serializer: toBooleanAttribute}) public isolation: boolean;
+  /** Template to use for isolated rendering */
+  @attr({defaultValue: 'default'}) public isolationTemplate: string;
+
+  protected _iframeResizeRAF: number = 0;
 
   /** {@link UIPPlugin} section wrapper */
   @memoize()
   protected get $inner(): HTMLElement {
     const pluginType = this.constructor as typeof UIPPlugin;
     return <div className={`${pluginType.is}-inner uip-plugin-inner esl-scrollable-content`}></div> as HTMLElement;
+  }
+
+  @memoize()
+  protected get $iframe(): HTMLIFrameElement {
+    return <iframe className="uip-preview-iframe" frameBorder="0"></iframe> as HTMLIFrameElement;
   }
 
   /** Extra element to animate decreasing height of content smoothly */
@@ -34,11 +51,11 @@ export class UIPPreview extends UIPPlugin {
     ) as HTMLElement;
   }
 
-  /** Changes preview markup from state changes */
+  /** Updates preview content from the model state changes */
   @listen({event: 'uip:change', target: ($this: UIPPreview) => $this.$root})
   protected _onRootStateChange(): void {
     this.$container.style.minHeight = `${this.$inner.offsetHeight}px`;
-    this.$inner.innerHTML = UIPRenderingPreprocessorService.preprocess(this.model!.html);
+    this.isolation ? this.writeContentIsolated() : this.writeContent();
 
     afterNextRender(() => this.$container.style.minHeight = '0px');
     skipOneRender(() => {
@@ -57,9 +74,51 @@ export class UIPPreview extends UIPPlugin {
     super.disconnectedCallback();
   }
 
+  /** Writes the content directly to the inner area (non-isolated frame) */
+  protected writeContent(): void {
+    this.$inner.innerHTML = UIPRenderingPreprocessorService.preprocess(this.model!.html);
+    this.stopIframeResizeLoop();
+  }
+
+  /** Writes the content to the iframe inner (isolated frame) */
+  protected writeContentIsolated(): void {
+    if (this.$iframe.parentElement !== this.$inner) {
+      this.$inner.innerHTML = '';
+      this.$inner.appendChild(this.$iframe);
+      this.startIframeResizeLoop();
+    }
+
+    const title = this.model!.activeSnippet?.label || 'UI Playground';
+    const content = UIPRenderingPreprocessorService.preprocess(this.model!.html);
+    const html = UIPRenderingTemplatesService.render(this.isolationTemplate, {title, content});
+
+    this.$iframe.contentWindow?.document.open();
+    this.$iframe.contentWindow?.document.write(html);
+    this.$iframe.contentWindow?.document.close();
+  }
+
+  /** Start and do a resize sync-loop iteration. Recall itself on the next frame. */
+  protected startIframeResizeLoop(): void {
+    // Prevents multiple loops
+    if (this._iframeResizeRAF) cancelAnimationFrame(this._iframeResizeRAF);
+    // Addition loop fallback for iframe removal
+    if (this.$iframe.parentElement !== this.$inner) return;
+    // Reflect iframe height with inner content
+    this.$iframe.style.height = `${this.$iframe.contentWindow?.document.body.scrollHeight}px`;
+    this._iframeResizeRAF = requestAnimationFrame(this.startIframeResizeLoop.bind(this));
+  }
+
+  /** Stop resize loop iterations created by `startIframeResizeLoop` */
+  protected stopIframeResizeLoop(): void {
+    if (!this._iframeResizeRAF) return;
+    cancelAnimationFrame(this._iframeResizeRAF);
+    this._iframeResizeRAF = 0;
+  }
+
   protected override attributeChangedCallback(attrName: string, oldVal: string, newVal: string): void {
     if (attrName === 'resizable' && newVal === null) this.clearInlineSize();
     if (attrName === 'dir') this.updateDir();
+    if (attrName === 'isolation' || attrName === 'isolation-template') this._onRootStateChange();
   }
 
   /** Resets element both inline height and width properties */
@@ -81,5 +140,14 @@ export class UIPPreview extends UIPPlugin {
   protected _onTransitionEnd(e: TransitionEvent): void {
     if (e.propertyName !== 'min-height') return;
     this.$container.style.removeProperty('min-height');
+  }
+
+  /** Handles visibility change of the preview are to limit resize sync-loops to the active preview area */
+  @listen({
+    event: 'intersects',
+    target: (preview: UIPPreview) => ESLIntersectionTarget.for(preview.$container, {threshold: 0.01}),
+  })
+  protected _onIntersects(e: ESLIntersectionEvent): void {
+    e.isIntersecting ? this.startIframeResizeLoop() : this.stopIframeResizeLoop();
   }
 }

--- a/src/core/preview/preview.tsx
+++ b/src/core/preview/preview.tsx
@@ -89,8 +89,9 @@ export class UIPPreview extends UIPPlugin {
     }
 
     const title = this.model!.activeSnippet?.label || 'UI Playground';
+    const script = this.model!.js;
     const content = UIPRenderingPreprocessorService.preprocess(this.model!.html);
-    const html = UIPRenderingTemplatesService.render(this.isolationTemplate, {title, content});
+    const html = UIPRenderingTemplatesService.render(this.isolationTemplate, {title, content, script});
 
     this.$iframe.contentWindow?.document.open();
     this.$iframe.contentWindow?.document.write(html);

--- a/src/core/preview/preview.tsx
+++ b/src/core/preview/preview.tsx
@@ -7,7 +7,7 @@ import {afterNextRender, skipOneRender} from '@exadel/esl/modules/esl-utils/asyn
 
 import {UIPPlugin} from '../base/plugin';
 import {UIPRenderingTemplatesService} from '../processors/templates';
-import {UIPRenderingPreprocessorService} from '../processors/rendering';
+import {UIPJSRenderingPreprocessors, UIPHTMLRenderingPreprocessors} from '../processors/rendering';
 
 import type {ESLIntersectionEvent} from '@exadel/esl/modules/esl-event-listener/core';
 
@@ -76,7 +76,7 @@ export class UIPPreview extends UIPPlugin {
 
   /** Writes the content directly to the inner area (non-isolated frame) */
   protected writeContent(): void {
-    this.$inner.innerHTML = UIPRenderingPreprocessorService.preprocess(this.model!.html);
+    this.$inner.innerHTML = UIPHTMLRenderingPreprocessors.preprocess(this.model!.html);
     this.stopIframeResizeLoop();
   }
 
@@ -89,8 +89,8 @@ export class UIPPreview extends UIPPlugin {
     }
 
     const title = this.model!.activeSnippet?.label || 'UI Playground';
-    const script = this.model!.js;
-    const content = UIPRenderingPreprocessorService.preprocess(this.model!.html);
+    const script = UIPJSRenderingPreprocessors.preprocess(this.model!.js);
+    const content = UIPHTMLRenderingPreprocessors.preprocess(this.model!.html);
     const html = UIPRenderingTemplatesService.render(this.isolationTemplate, {title, content, script});
 
     this.$iframe.contentWindow?.document.open();

--- a/src/core/processors/normalization.ts
+++ b/src/core/processors/normalization.ts
@@ -1,60 +1,36 @@
-/** Function to process html string for normalization*/
-export type UIPNormalizationProcessor = ((input: string) => string) & {
-  htmlOnly?: boolean;
-};
+import {UIPPreprocessorService} from './preprocessor';
 
-export class UIPNormalizationService {
-  /** Processor storage */
-  protected static processors: Record<string, UIPNormalizationProcessor> = {};
+/**
+ * Normalization processors store for JS content.
+ * Normalization transformation are used to normalize content before displaying or processing.
+ */
+export const UIPJSNormalizationPreprocessors = new UIPPreprocessorService();
+/**
+ * Normalization processors store for HTML content.
+ * Normalization transformation are used to normalize content before displaying or processing.
+ */
+export const UIPHTMLNormalizationPreprocessors = new UIPPreprocessorService();
 
-  /** Add processor function to normalization process */
-  public static addProcessor(
-    name: string,
-    processor: UIPNormalizationProcessor,
-    htmlOnly = false
-  ): void {
-    Object.assign(processor, {htmlOnly});
-    UIPNormalizationService.processors[name] = processor;
-  }
 
-  /** Normalizes passes content string by running all registered processors in chain */
-  public static normalize(content: string, isHtml = true): string {
-    return Object.keys(UIPNormalizationService.processors)
-      .map((name) => UIPNormalizationService.processors[name])
-      .filter((processor) => typeof processor === 'function')
-      .filter((processor) => !processor.htmlOnly || isHtml)
-      .reduce((input, processor) => processor(input), content);
-  }
+/** Removes extra indents to beautify content alignment */
+export function removeIndent(input: string): string {
+  // Get all indents from text
+  const indents = input.match(/^[^\S\n\r]*(?=\S)/gm);
+  // No processing if no indent on the first line or input is empty
+  if (!indents || !indents[0].length) return input;
+  // Sort indents by length
+  indents.sort((a, b) => a.length - b.length);
+  // No processing if minimal indent is 0
+  if (!indents[0].length) return input;
+  // Remove indents from text
+  return input.replace(RegExp('^' + indents[0], 'gm'), '');
 }
+UIPJSNormalizationPreprocessors.add('remove-leading-indent', removeIndent);
+UIPHTMLNormalizationPreprocessors.add('remove-leading-indent', removeIndent);
 
-/** Removes extra indents */
-UIPNormalizationService.addProcessor(
-  'remove-indent',
-  (input: string): string => {
-    // Get all indents from text
-    const indents = input.match(/^[^\S\n\r]*(?=\S)/gm);
-    // No processing if no indent on the first line or input is empty
-    if (!indents || !indents[0].length) return input;
-    // Sort indents by length
-    indents.sort((a, b) => a.length - b.length);
-    // No processing if minimal indent is 0
-    if (!indents[0].length) return input;
-    // Remove indents from text
-    return input.replace(RegExp('^' + indents[0], 'gm'), '');
-  }
-);
-/** Removes extra spaces */
-// TODO: handle case with inline script with literal double spaces
-UIPNormalizationService.addProcessor(
-  'remove-trailing',
-  (input: string) => input.replace(/\s*?$/gm, ''),
-  true
-);
-/** Remove beginning spaces */
-UIPNormalizationService.addProcessor('left-trim', (input: string) =>
-  input.replace(/^\s+/, '')
-);
-/** Remove ending spaces */
-UIPNormalizationService.addProcessor('right-trim', (input: string) =>
-  input.replace(/\s+$/, '')
-);
+/** Trim content */
+UIPJSNormalizationPreprocessors.add('trim', (content: string) => content.trim());
+UIPHTMLNormalizationPreprocessors.add('trim', (content: string) => content.trim());
+
+/** Removes extra spaces inside the content. Applicable for HTML only */
+UIPHTMLNormalizationPreprocessors.addRegexReplacer('remove-trailing', /\s*?$/gm, '');

--- a/src/core/processors/preprocessor.ts
+++ b/src/core/processors/preprocessor.ts
@@ -1,0 +1,43 @@
+/** Pre-processor function, called to process content */
+export type UIPTransformer = (input: string) => string;
+
+/** Rendering pre-processor service, that stores collection of {@link UIPRenderingPreprocessor}s */
+export class UIPPreprocessorService {
+  /** Pre-processor storage */
+  protected preprocessors: Record<string, UIPTransformer> = {};
+
+  /** Add pre-processor {@link UIPRenderingPreprocessor} */
+  public add(name: string, preprocessor: UIPTransformer): void {
+    this.preprocessors[name] = preprocessor;
+  }
+
+  /** Add pre-processor alias */
+  public addAlias(name: string, alias: string): void {
+    this.preprocessors[name] = this.preprocessors[alias];
+  }
+
+  /** Add pre-processor with RegExp replacer */
+  public addRegexReplacer(name: string, regex: RegExp, replaceValue: string): void;
+  /** Add pre-processor with RegExp replacer */
+  public addRegexReplacer(name: string, regex: RegExp, replacer: (substring: string, ...args: any[]) => string): void;
+  public addRegexReplacer(name: string, regex: RegExp, replacer: any): void {
+    this.add(name, (input) => input.replace(regex, replacer));
+  }
+
+  public get(name: string): UIPTransformer | undefined {
+    return this.preprocessors[name];
+  }
+
+  /** Pre-process html content */
+  public preprocess(html: string): string {
+    return Object.keys(this.preprocessors)
+      .map((name) => this.preprocessors[name])
+      .filter((preprocessor) => typeof preprocessor === 'function')
+      .reduce((input, preprocessor) => preprocessor(input), html);
+  }
+
+  /** Clear all pre-processors */
+  public clear(): void {
+    this.preprocessors = {};
+  }
+}

--- a/src/core/processors/rendering.ts
+++ b/src/core/processors/rendering.ts
@@ -1,48 +1,25 @@
 import {ESLRandomText} from '@exadel/esl/modules/esl-random-text/core';
+import {UIPPreprocessorService} from './preprocessor';
 
-/** Rendering pre-processor function, called before rendering, does not affect the content in plugins */
-export type UIPRenderingPreprocessor = (input: string) => string;
-
-/** Rendering pre-processor service, that stores collection of {@link UIPRenderingPreprocessor}s */
-export class UIPRenderingPreprocessorService {
-  protected static preprocessors: Record<string, UIPRenderingPreprocessor> = {};
-
-  /** Add pre-processor {@link UIPRenderingPreprocessor} */
-  public static addPreprocessor(name: string, preprocessor: UIPRenderingPreprocessor): void {
-    UIPRenderingPreprocessorService.preprocessors[name] = preprocessor;
-  }
-
-  /** Add pre-processor with RegExp replacer */
-  public static addRegexPreprocessor(name: string, regex: RegExp, replacer: Parameters<typeof String.prototype.replace>[1]): void {
-    this.addPreprocessor(name, (input) => input.replace(regex, replacer));
-  }
-
-  /** Add pre-processor alias */
-  public static addPreprocessorAlias(name: string, alias: string): void {
-    UIPRenderingPreprocessorService.preprocessors[name] = UIPRenderingPreprocessorService.preprocessors[alias];
-  }
-
-  /** Pre-process html content */
-  public static preprocess(html: string): string {
-    return Object.keys(UIPRenderingPreprocessorService.preprocessors)
-      .map((name) => UIPRenderingPreprocessorService.preprocessors[name])
-      .filter((preprocessor) => typeof preprocessor === 'function')
-      .reduce((input, preprocessor) => preprocessor(input), html);
-  }
-
-  /** Clear all pre-processors */
-  public static clear(): void {
-    UIPRenderingPreprocessorService.preprocessors = {};
-  }
-}
+/**
+ * Pre-processor services for JS content.
+ * Rendering preprocessors applied to content before rendering and does not affect editor's content
+ */
+export const UIPJSRenderingPreprocessors = new UIPPreprocessorService();
+/**
+ * Pre-processor services for HTML content.
+ * Rendering preprocessors applied to content before rendering and does not affect editor's content
+ */
+export const UIPHTMLRenderingPreprocessors = new UIPPreprocessorService();
 
 // Register default pre-processors
-UIPRenderingPreprocessorService.addRegexPreprocessor('text', /<!--\s*text\s*x?(\d+)?\s*-->/g, (term, count) => {
+
+UIPHTMLRenderingPreprocessors.addRegexReplacer('text', /<!--\s*text\s*x?(\d+)?\s*-->/g, (term, count) => {
   const length = count ? parseInt(count, 10) : 10;
   return ESLRandomText.generateText(length);
 });
 
-UIPRenderingPreprocessorService.addRegexPreprocessor('text-html', /<!--\s*(text-html|paragraph)\s*x?(\d+)?\s*-->/g, (term, name, count) => {
+UIPHTMLRenderingPreprocessors.addRegexReplacer('text-html', /<!--\s*(text-html|paragraph)\s*x?(\d+)?\s*-->/g, (term, name, count) => {
   const length = count ? parseInt(count, 10) : 100;
   return ESLRandomText.generateTextHTML(100 * length);
 });

--- a/src/core/processors/templates.ts
+++ b/src/core/processors/templates.ts
@@ -2,6 +2,7 @@ import {format} from '@exadel/esl/modules/esl-utils/misc';
 
 interface UIPRenderingTemplateParams {
   title?: string;
+  script?: string;
   content: string;
   [additional: string]: string | number | boolean | undefined | null;
 }
@@ -31,9 +32,8 @@ UIPRenderingTemplatesService.add('default', `
   <html>
     <head>
       <title>{title}</title>
+      <script type="module">{script}</script>
     </head>
-    <body>
-      {content}
-    </body>
+    <body>{content}</body>
   </html>
 `);

--- a/src/core/processors/templates.ts
+++ b/src/core/processors/templates.ts
@@ -1,0 +1,39 @@
+import {format} from '@exadel/esl/modules/esl-utils/misc';
+
+interface UIPRenderingTemplateParams {
+  title?: string;
+  content: string;
+  [additional: string]: string | number | boolean | undefined | null;
+}
+
+export class UIPRenderingTemplatesService {
+  /** Template storage */
+  protected static templates = new Map<string, string>();
+
+  /** Register template */
+  public static add(name: string, template: string): void {
+    this.templates.set(name, template);
+  }
+  /** Get template */
+  public static get(name: string): string | undefined {
+    return this.templates.get(name);
+  }
+
+  /** Render template */
+  public static render(name: string, params: UIPRenderingTemplateParams): string {
+    const template = this.get(name);
+    if (!template) return params.content;
+    return format(template, params);
+  }
+}
+
+UIPRenderingTemplatesService.add('default', `
+  <html>
+    <head>
+      <title>{title}</title>
+    </head>
+    <body>
+      {content}
+    </body>
+  </html>
+`);

--- a/src/plugins/editor/editor.less
+++ b/src/plugins/editor/editor.less
@@ -1,6 +1,10 @@
 .uip-editor {
   grid-area: editor;
 
+  &[script] {
+    grid-area: editor-js;
+  }
+
   &-inner {
     display: flex;
     padding: 1em;

--- a/src/plugins/editor/editor.tsx
+++ b/src/plugins/editor/editor.tsx
@@ -26,6 +26,9 @@ export class UIPEditor extends UIPPluginPanel {
   /** Highlight method declaration  */
   public static highlight = (editor: HTMLElement): void => Prism.highlightElement(editor, false);
 
+  /** Marker of JS Editor */
+  @boolAttr() public script: boolean;
+
   /** Marker to display copy widget */
   @boolAttr({name: 'copy'}) public showCopy: boolean;
 
@@ -61,7 +64,8 @@ export class UIPEditor extends UIPPluginPanel {
   @memoize()
   protected get $code(): HTMLElement {
     const type = this.constructor as typeof UIPEditor;
-    return (<pre class={type.is + '-code language-html'}><code/></pre>) as HTMLElement;
+    const lang = this.script ? 'javascript' : 'html';
+    return (<pre class={type.is + '-code language-' + lang}><code/></pre>) as HTMLElement;
   }
 
   /** Wrapped [CodeJar](https://medv.io/codejar/) editor instance */
@@ -110,15 +114,16 @@ export class UIPEditor extends UIPPluginPanel {
   }
 
   /** Callback to call on an editor's content changes */
-  @decorate(debounce, 1000)
+  @decorate(debounce, 2000)
   protected _onChange(): void {
-    this.model!.setHtml(this.value, this);
+    if (this.script) this.model!.setJS(this.value, this);
+    else this.model!.setHtml(this.value, this);
   }
 
   /** Change editor's markup from markup state changes */
   @listen({event: 'uip:change', target: ($this: UIPEditor) => $this.$root})
   protected _onRootStateChange(): void {
     if (this.model!.lastModifier === this) return;
-    this.value = this.model!.html;
+    this.value = this.script ? this.model!.js : this.model!.html;
   }
 }


### PR DESCRIPTION
- Add support for isolated rendering (inside iframe)
- Add a service to store isolated iframe templates
- ~Generalize normalization preprocessor (for JS support)~
  ~NOTE: needs refactoring to classify processors into 3 groups (instead of 2) : 'html' , 'script', 'both'~
- Add basic JS state store into the model
  NOTE: needs update for event details of the model to classify changes for HTML / JS related to optimize submodule rerendering
- Add support for JS Snippets
  NOTE: needs refactoring
  TODO: move selection into one service
- Add basic support for editor mods 
  NOTE: needs refactoring / bug fixing
  NOTE: needs API review
 
 JS support presented in this update is absolutely on the base level, still needs refactoring and bugfixing to make predictable API, update flow, and support by all features.
  
